### PR TITLE
Improve data support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 lib-cov/
 html-report/
 lcov.info
+coverage

--- a/README.md
+++ b/README.md
@@ -20,14 +20,29 @@ $ npm i express-bem-bh --save
 ## Usage
 
 ```js
-var Express = require('express');
-var ExpressBem = require('express-bem');
+var express = require('express');
+var expressBem = require('express-bem')(/*params*/); // see the `express-bem` documentation to learn more about params
 
-var app = Express();
-var bem = ExpressBem({root: './path-to/bem-project'}).bindTo(app);
+var app = express();
 
-// simple
-bem.usePlugin('express-bem-bh', {force: true, source: '_?.bh.js'});
+expressBem.bindTo(app);
+expressBem.usePlugin('express-bem-bh', {
+    force: true, // drops the template requiring cache for every request, it makes reason to use in development environment
+    source: '_?.bh.js', // the enb-style wildcard to specify a template name (for example, it will render _index.bh.js for the index page)
+    dataKey: 'data' // name of the field that will contain data into templates, see how to use below
+});
+
+app.get('/', function (req, res) {
+    res.locals.bemjson = {block: 'test'};
+
+    // any data to use into templates
+    // it will be available in templates as `ctx.json().data.message`
+    res.locals.message = 'Use bh with your Express application';
+
+    res.render('pageName');
+});
+
+app.listen(3000);
 ```
 
 ## License

--- a/lib/engines/bh.js
+++ b/lib/engines/bh.js
@@ -9,10 +9,10 @@ module.exports = function (opts) {
      * bh.js express view engine adapter
      * Produces html from bh-templates and data and invokes passed callback with result
      *
-     * @param   {String}     name       bundle name
-     * @param   {Object}     [options]  data to use in templates
-     * @param   {Function}   cb         callback to invoke with result or error
-     * @returns {Undefined}             undefined value
+     * @param {String} name Bundle name
+     * @param {Object} [options] Data to use in templates
+     * @param {Function} cb Callback to invoke with result or error
+     * @returns {Undefined}
      */
     function bh(name, options, cb) {
         var filePath;

--- a/lib/engines/bh.js
+++ b/lib/engines/bh.js
@@ -7,37 +7,49 @@ module.exports = function (opts) {
 
     /**
      * bh.js express view engine adapter
-     * @api
-     * @returns {function(string, Object, Function)}
+     * Produces html from bh-templates and data and invokes passed callback with result
+     *
+     * @param   {String}     name       bundle name
+     * @param   {Object}     [options]  data to use in templates
+     * @param   {Function}   cb         callback to invoke with result or error
+     * @returns {Undefined}             undefined value
      */
     function bh(name, options, cb) {
+        var filePath;
+        var bhModule;
+        var html;
+
         // reject rendering for empty options.bemjson
         if (!options.bemjson) {
-            cb(Error('Empty request'));
+            cb(Error('No bemjson was passed'));
             return;
         }
 
-        name = U.fulfillName(name, opts.ext || this.ext, opts.source);
+        filePath = U.fulfillName(name, opts.ext || this.ext, opts.source);
 
-        // pass to render
+        // check cache options
         if (opts.force || options.forceExec || options.forceLoad) {
             dropRequireCache(require, name);
         }
 
-        var bhModule;
         try {
-            bhModule = require(name);
+            bhModule = require(filePath);
         } catch (e) {
             cb(e);
             return;
         }
 
-        if (!bhModule || !bhModule.apply) {
-            cb(new Error('Unknown file format'));
+        // add data to use in templates
+        options.bemjson.data = bhModule.utils.extend({}, options);
+        delete options.bemjson.data.bemjson;
+
+        try {
+            html = bhModule.apply(options.bemjson);
+        } catch (e) {
+            cb(e);
             return;
         }
 
-        // Renders bemjson to html via bh
-        cb(null, bhModule.apply(options.bemjson));
+        cb(null, html);
     }
 };

--- a/lib/engines/bh.js
+++ b/lib/engines/bh.js
@@ -40,8 +40,10 @@ module.exports = function (opts) {
         }
 
         // add data to use in templates
-        options.bemjson.data = bhModule.utils.extend({}, options);
-        delete options.bemjson.data.bemjson;
+        if (opts.dataKey) {
+            options.bemjson[opts.dataKey] = bhModule.utils.extend({}, options);
+            delete options.bemjson[opts.dataKey].bemjson;
+        }
 
         try {
             html = bhModule.apply(options.bemjson);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "jshint lib test && jscs lib test",
-    "test": "npm run lint && mocha"
+    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- -u bdd -R spec --recursive test",
+    "test": "npm run lint && mocha && npm run coverage"
   },
   "repository": {
     "type": "git",
@@ -31,6 +32,7 @@
     "jscs": "^1.5.9",
     "jshint": "^2.5.4",
     "mocha": "*",
+    "istanbul": "0.3.5",
     "request": "*"
   },
   "files": [

--- a/test/01.basic-render.js
+++ b/test/01.basic-render.js
@@ -49,7 +49,7 @@ describe('basic renders', function () {
     it('should pass data to templates', function (done) {
         var app = EXPRESS();
         var bem = EXPRESSBEM(bemOpts).bindTo(app);
-        bem.usePlugin(EXPRESSBH);
+        bem.usePlugin(EXPRESSBH, {dataKey: 'data'});
 
         app.render('use-data', {bemjson: bemjson, foo: 'bar'}, function (err, html) {
             ASSERT.notEqual(html.indexOf('bar'), -1);

--- a/test/01.basic-render.js
+++ b/test/01.basic-render.js
@@ -10,6 +10,7 @@ describe('basic renders', function () {
     };
     var content = 'Hey ho let\'s go!';
     var bemjson;
+
     beforeEach(function () {
         bemjson = {
             block: 'page',
@@ -44,4 +45,16 @@ describe('basic renders', function () {
             done();
         });
     });
+
+    it('should pass data to templates', function (done) {
+        var app = EXPRESS();
+        var bem = EXPRESSBEM(bemOpts).bindTo(app);
+        bem.usePlugin(EXPRESSBH);
+
+        app.render('use-data', {bemjson: bemjson, foo: 'bar'}, function (err, html) {
+            ASSERT.notEqual(html.indexOf('bar'), -1);
+            done();
+        });
+    });
+
 });

--- a/test/02.errors-handling.js
+++ b/test/02.errors-handling.js
@@ -1,0 +1,40 @@
+var ASSERT = require('assert');
+var EXPRESS = require('express');
+var EXPRESSBEM = require('express-bem');
+var EXPRESSBH = require('../lib');
+
+var bemOpts = {
+    root: './test/data/views',
+    path: 'pages'
+};
+var bemjson = {
+    block: 'page',
+    title: 'Example',
+    content: 'Hey ho let\'s go!'
+};
+
+describe('errors-handling', function () {
+
+    it('should return an error if bemjson wasn\'t passed', function (done) {
+        var app = EXPRESS();
+        var bem = EXPRESSBEM(bemOpts).bindTo(app);
+        bem.usePlugin(EXPRESSBH);
+
+        app.render('custom', {}, function (err) {
+            ASSERT.notEqual(err, null);
+            done();
+        });
+    });
+
+    it('should return an error if it happens on the bh.apply() step', function (done) {
+        var app = EXPRESS();
+        var bem = EXPRESSBEM(bemOpts).bindTo(app);
+        bem.usePlugin(EXPRESSBH);
+
+        app.render('error-template', {bemjson: bemjson}, function (err) {
+            ASSERT.notEqual(err, null);
+            done();
+        });
+    });
+
+});

--- a/test/data/views/pages/error-template/error-template.bh.js
+++ b/test/data/views/pages/error-template/error-template.bh.js
@@ -1,0 +1,12 @@
+var BH = require('../../../../../node_modules/bh/lib/bh.js');
+var bh = new BH();
+
+bh.match('page', function (ctx) {
+    ctx
+        .tag('example')
+        .attr('name', 'value')
+        .error()
+        .content(ctx.json().data.name);
+});
+
+module.exports = bh;

--- a/test/data/views/pages/use-data/use-data.bh.js
+++ b/test/data/views/pages/use-data/use-data.bh.js
@@ -1,0 +1,8 @@
+var BH = require('../../../../../node_modules/bh/lib/bh.js');
+var bh = new BH();
+
+bh.match('page', function (ctx) {
+    ctx.content(ctx.json().data.foo, true);
+});
+
+module.exports = bh;


### PR DESCRIPTION
Hi, Alex!

I use pure Express, which exposes `locals` fields of `app` and `res` to collect data as native approach. I'd like to pass this data to templates. Please, look at what I propose in code.
It's the blocker thing, that stops me to use the module.
I don't want to do a fork with these changes. I want to improve this module instead.

BTW, I added code coverage to see how well tests work.
I wasn't able to write test for check the template requiring. I'll be glad if you'll help me with it at the future.

Ok, I look forward to your comments.
