### PR TITLE
Require `drop-require-cache` function only if it needed

### DIFF
--- a/lib/engines/bh.js
+++ b/lib/engines/bh.js
@@ -1,5 +1,5 @@
 var U = require('express-bem/lib/util');
-var dropRequireCache = require('enb/lib/fs/drop-require-cache');
+var dropRequireCache;
 
 module.exports = function (opts) {
     bh.extension = '.bh.js';
@@ -47,6 +47,8 @@ module.exports = function (opts) {
 
         // drop cache
         if (opts.force || options.forceExec || options.forceLoad) {
+            dropRequireCache = dropRequireCache || require('enb/lib/fs/drop-require-cache');
+
             dropRequireCache(require, filePath);
         }
 


### PR DESCRIPTION
If project runs in production environment, it doesn't have `enb` as a production dependency. But now the plugin requires function from `enb`. This fix proposes to require and invoke the function only if it needed. 

Other question for needs of support this ability is discussed [here](https://github.com/express-bem/bh/issues/4). But the fix is about another thing.
