### PR TITLE
v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-bem-bh",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "bh.js engine for express-bem",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
- Require `drop-require-cache` function only if it needed

Closes gh-10
